### PR TITLE
Suggested fixes to modernize the code a bit

### DIFF
--- a/Card.cpp
+++ b/Card.cpp
@@ -1,30 +1,6 @@
 #include "Card.hpp"
 
-Card::Card()
-{
-	// The instructions should be their default selves
-}
-
 Card::Card(const Instruction& i0, const Instruction& i1)
+    : instructions{i0, i1} // use initializer list for initialization
 {
-	instructions[0] = i0;
-	instructions[1] = i1;
-}
-
-Card::Card(const Card& other)
-{
-	instructions[0] = other.instructions[0];
-	instructions[1] = other.instructions[1];
-}
-
-Card::Card(Card&& other)
-{
-	instructions[0] = other.instructions[0];
-	instructions[1] = other.instructions[1];
-}
-
-void Card::operator=(const Card& other)
-{
-	instructions[0] = other.instructions[0];
-	instructions[1] = other.instructions[1];
 }

--- a/Card.hpp
+++ b/Card.hpp
@@ -5,12 +5,8 @@
 class Card 
 {
 public:
-	Instruction         instructions[2];
+	Instruction         instructions[2] = {}; // direct member initialization to avoid cluttering up constructors, or leaving member uninitialized
 
-						Card();
+						Card() = default; // if direct initializion is done, we can let the compiler generate this ctor for us
 						Card(const Instruction& i0, const Instruction& i1);
-						Card(const Card& other);
-						Card(Card&& other);
-
-	void				operator=(const Card& other);
 };

--- a/Instruction.cpp
+++ b/Instruction.cpp
@@ -1,36 +1,10 @@
 #include "Instruction.hpp"
 
-Instruction::Instruction() 
-{
-	moveType = MoveType::STAY;
-	overwrite = 0;
-	nextCard = 0;
-}
-
 Instruction::Instruction(MoveType m, bool o, unsigned int n) 
+    : moveType(m), overwrite(o), nextCard(n)
+    // When initializing in constructor (as opposed to direct member initialization
+    // like I did elsewhere 
+    // prefer the initialization list instead of ctor body
 {
-	moveType = m;	
-	overwrite = o;
-	nextCard = n;
 }
 
-Instruction::Instruction(const Instruction& other) 
-{
-	moveType = other.moveType;	
-	overwrite = other.overwrite;
-	nextCard = other.nextCard;
-}
-
-Instruction::Instruction(Instruction&& other) 
-{
-	moveType = other.moveType;	
-	overwrite = other.overwrite;
-	nextCard = other.nextCard;
-}
-
-void Instruction::operator=(const Instruction& other)
-{
-	moveType = other.moveType;	
-	overwrite = other.overwrite;
-	nextCard = other.nextCard;
-}

--- a/Instruction.hpp
+++ b/Instruction.hpp
@@ -14,14 +14,15 @@ enum class MoveType
 class Instruction 
 {
 public:
-					Instruction();
+					Instruction() = default;
 					Instruction(MoveType m, bool o, unsigned int n);
-					Instruction(const Instruction& other);
-					Instruction(Instruction&& other);
+                    // As long as you don't do anything to make it impossible, (const or ref members)
+                    // the compiler will generate copy ctor and copy assignment operator for you, so no need for explicit ones
+                    // Also no need for move ctor unless you semantically want class to be noncopyable,
+                    // or if it contains members that are expensive to copy
+                    // So get rid of that too
 
-	void			operator=(const Instruction& other);
-
-	MoveType 		moveType; 		// How to move the pointer next time around
-	bool 			overwrite;	 	// What to overwrite the current place with
-	unsigned int 	nextCard; 		// What next card to go to
+	MoveType 		moveType = MoveType::STAY; 		// How to move the pointer next time around
+	bool 			overwrite = false;	 	// What to overwrite the current place with
+	unsigned int 	nextCard = 0; 		// What next card to go to
 };

--- a/TuringMachine.cpp
+++ b/TuringMachine.cpp
@@ -3,10 +3,12 @@
 /*
  * Private Functions
  */
-void TuringMachine::InitializeMemory()
-{
-	memory.push_back(false);
-	currentPos = memory.begin();
+
+// by returning the finished vector, we can initialize it properly in the ctor initialization list
+std::list<bool> InitializeMemory(const std::list<bool>& init) {
+    std::list<bool> v(init);
+    v.push_back(false);
+    return v;
 }
 
 void TuringMachine::ExecuteInstruction(const Instruction& i)
@@ -41,22 +43,20 @@ void TuringMachine::ExecuteInstruction(const Instruction& i)
  * Constructors
  */
 TuringMachine::TuringMachine()
+    : memory({}), currentPos(memory.begin())
 {
-	InitializeMemory();
-	currentCard = 0;
 }
 
-TuringMachine::TuringMachine(std::vector<Card> cards_in, std::list<bool> memory_in) :
-	cards(cards_in), memory(memory_in)
+TuringMachine::TuringMachine(std::vector<Card> cards_in, std::list<bool> memory_in)
+	: cards(cards_in), memory(InitializeMemory(memory_in)), currentPos(memory.begin())
 {
-	InitializeMemory();
-	currentCard = 0;
 }
 
 TuringMachine::TuringMachine(TuringMachine&& other)
 {
 	cards = std::move(other.cards);
-	memory = std::move(other.memory);
+    // as far as I could tell, moving a container does not guarantee iterator validity, but swapping them does
+    std::swap(memory, other.memory);
 	currentPos = other.currentPos;
 	currentCard = other.currentCard;
 }
@@ -70,7 +70,7 @@ void TuringMachine::Tick()
 	ExecuteInstruction(cards[currentCard].instructions[*currentPos]);
 }
 
-const std::list<bool>& TuringMachine::PeakMemory()
+const std::list<bool>& TuringMachine::PeekMemory()
 {
 	return memory;
 }

--- a/TuringMachine.hpp
+++ b/TuringMachine.hpp
@@ -14,12 +14,7 @@ private:
 	std::list<bool>				memory;
 
 	std::list<bool>::iterator	currentPos;
-	unsigned int				currentCard;
-
-	/*
-	 * Initializes the memory of the TuringMachine.
-	 */
-	void						InitializeMemory();
+	unsigned int				currentCard = 0;
 
 	/*
 	 * Executes the given instruction, updating currentPos and currentCard
@@ -28,9 +23,11 @@ private:
 
 public:
 								TuringMachine();
-								TuringMachine(std::vector<Card> cards, std::list<bool> memory);
+                                TuringMachine(std::vector<Card> cards_in, std::list<bool> memory_in);
 								TuringMachine(const TuringMachine& other) = delete; // Can't copy this atm
+								TuringMachine& operator=(const TuringMachine& other) = delete; // Can't copy this atm
 								TuringMachine(TuringMachine&& other);
+								TuringMachine& operator=(TuringMachine&& other); // if you have a move ctor, you should also have a move assignment operator
 	
 	/*
 	 * Ticks the simulation forward by executing the next instruction
@@ -38,7 +35,9 @@ public:
 	void						Tick();
 
 	/*
-	 * Peaks at the memory of the TuringMachine
+	 * Peeks at the memory of the TuringMachine
 	 */
-	const std::list<bool>&		PeakMemory();
+	const std::list<bool>&		PeekMemory();
+
+private:
 };

--- a/main.cpp
+++ b/main.cpp
@@ -78,7 +78,7 @@ int main()
 			tm.Tick();
 
 			std::cout << "...000 ";
-			for (const auto& elem : tm.PeakMemory())
+			for (const auto& elem : tm.PeekMemory())
 			{
 				std::cout << elem;
 			}


### PR DESCRIPTION
Remove copy constructors and assignment operators in cases where the
compiler will autogenerate them.

Move initialization of members from
constructor body to initialization list or direct member initialization
as appropriate.

And avoid a potential iterator invalidation issue when moving
TuringMachine. (Swap the container to guarantee iterators remain valid)